### PR TITLE
Moved to python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 REPO_ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 UNAME_S  = $(shell uname -s)
-PYTHON  ?= python
+PYTHON  ?= /usr/bin/env python3
 PIP     ?= pip3
 PIPARGS ?=
 GOPATH  ?= $(HOME)/go


### PR DESCRIPTION
Fixes #

Changes:
Makefile now uses python3 instead of python2

Does this change need to mentioned in CHANGELOG.md?

No

Related issues:

PR skycoin/hardware-wallet# for issue skycoin/hardware-wallet#
PR skycoin/hardware-wallet-js# for issue skycoin/hardware-wallet-js#
PR skycoin/hardware-wallet-go# for issue skycoin/hardware-wallet-go#

